### PR TITLE
Enhance accessibility

### DIFF
--- a/src/components/FlashCard.vue
+++ b/src/components/FlashCard.vue
@@ -8,9 +8,21 @@
                 <div class="h-1/3"><p><b>의미</b></p><p id="means" style="font-size: 1.2rem;" :class="{ hide: hideMeans }"> {{ means.join(', ') }}</p></div>
             </div>
             <div class="w-full md:w-1/4 mt-4">
-                <div class="w-1/3 inline-block md:w-full md:h-1/3"><b>품사 가리기</b>:<input type="checkbox" v-model="hideParts"></div>
-                <div class="w-1/3 inline-block md:w-full md:h-1/3"><b>발음 가리기</b>:<input type="checkbox" v-model="hidePron"></div>
-                <div class="w-1/3 inline-block md:w-full md:h-1/3"><b>의미 가리기</b>:<input type="checkbox" v-model="hideMeans"></div>
+				<label for="hideParts">
+					<div class="w-full inline-block md:h-1/3 cursor-pointer py-1 md:py-0">
+						<b>품사 가리기</b>:<input id="hideParts" type="checkbox" v-model="hideParts">
+					</div>
+				</label>
+				<label for="hidePron">
+					<div class="w-full inline-block md:h-1/3 cursor-pointer py-1 md:py-0">
+						<b>발음 가리기</b>:<input id="hidePron" type="checkbox" v-model="hidePron">
+					</div>
+				</label>
+				<label for="hideMeans">
+					<div class="w-full inline-block md:h-1/3 cursor-pointer py-1 md:py-0">
+						<b>의미 가리기</b>:<input id="hideMeans" type="checkbox" v-model="hideMeans">
+					</div>
+				</label>
             </div> 
         </div>
     </div>


### PR DESCRIPTION
모바일 환경이나 데스크탑 환경이나 체크박스 버튼을 클릭해야만 하는 불편함이 있을 것으로 파악됩니다.
또한, 작은 화면을 이용하게 될 경우, UI가 깨져보이는 잠재적인 문제가 있을 것으로도 파악됩니다.

1. 품사 가리기/발음 가리기/의미 가리기 버튼을 모바일 화면에서도 여러개의 라인으로 분리되도록 했습니다.
2. 체크박스 뿐만 아니라 텍스트를 클릭해도 가리기 기능이 동작하도록 하여 모바일 화면에서 좀 더 쾌적하게 이용할 수 있도록 했습니다.